### PR TITLE
feat(DB): Update schema migration with folder, file, share table

### DIFF
--- a/drizzle/0002_yellow_mojo.sql
+++ b/drizzle/0002_yellow_mojo.sql
@@ -1,0 +1,54 @@
+CREATE TABLE "files" (
+	"id" uuid PRIMARY KEY DEFAULT uuid_generate_v4
+      () NOT NULL,
+	"name" varchar(255) NOT NULL,
+	"mimeType" varchar(100) NOT NULL,
+	"size" integer NOT NULL,
+	"path" text NOT NULL,
+	"folderId" uuid,
+	"ownerId" uuid NOT NULL,
+	"deletedAt" timestamp,
+	"createdAt" timestamp DEFAULT now
+      ()
+);
+--> statement-breakpoint
+CREATE TABLE "folders" (
+	"id" uuid PRIMARY KEY DEFAULT uuid_generate_v4
+      () NOT NULL,
+	"name" varchar(255) NOT NULL,
+	"ownerId" uuid NOT NULL,
+	"parentId" uuid,
+	"deletedAt" timestamp,
+	"createdAt" timestamp DEFAULT now
+      ()
+);
+--> statement-breakpoint
+CREATE TABLE "shares" (
+	"id" uuid PRIMARY KEY DEFAULT uuid_generate_v4
+      () NOT NULL,
+	"token" varchar(64) NOT NULL,
+	"fileId" uuid,
+	"folderId" uuid,
+	"createdBy" uuid NOT NULL,
+	"password" varchar(100),
+	"expiresAt" timestamp,
+	"downloadCount" integer DEFAULT 0,
+	"createdAt" timestamp DEFAULT now
+      (),
+	CONSTRAINT "shares_token_unique" UNIQUE("token")
+);
+--> statement-breakpoint
+ALTER TABLE "files" ADD CONSTRAINT "files_folderId_folders_id_fk" FOREIGN KEY ("folderId") REFERENCES "public"."folders"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "files" ADD CONSTRAINT "files_ownerId_users_id_fk" FOREIGN KEY ("ownerId") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "folders" ADD CONSTRAINT "folders_ownerId_users_id_fk" FOREIGN KEY ("ownerId") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "folders" ADD CONSTRAINT "folders_parentId_folders_id_fk" FOREIGN KEY ("parentId") REFERENCES "public"."folders"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "shares" ADD CONSTRAINT "shares_fileId_files_id_fk" FOREIGN KEY ("fileId") REFERENCES "public"."files"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "shares" ADD CONSTRAINT "shares_folderId_folders_id_fk" FOREIGN KEY ("folderId") REFERENCES "public"."folders"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "shares" ADD CONSTRAINT "shares_createdBy_users_id_fk" FOREIGN KEY ("createdBy") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "idx_file_owner" ON "files" USING btree ("ownerId");--> statement-breakpoint
+CREATE INDEX "idx_file_folder" ON "files" USING btree ("folderId");--> statement-breakpoint
+CREATE INDEX "idx_folder_owner" ON "folders" USING btree ("ownerId");--> statement-breakpoint
+CREATE INDEX "idx_share_file" ON "shares" USING btree ("fileId");--> statement-breakpoint
+CREATE INDEX "idx_share_folder" ON "shares" USING btree ("folderId");--> statement-breakpoint
+CREATE INDEX "idx_share_created_by" ON "shares" USING btree ("createdBy");--> statement-breakpoint
+ALTER TABLE "users" DROP COLUMN "deletedAt";

--- a/drizzle/meta/0002_snapshot.json
+++ b/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,493 @@
+{
+  "id": "4554c4a9-d920-4a84-95f5-29f51c1d3d67",
+  "prevId": "cdede107-9a54-4082-8f58-07784552ae2c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.files": {
+      "name": "files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4\n      ()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mimeType": {
+          "name": "mimeType",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "folderId": {
+          "name": "folderId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now\n      ()"
+        }
+      },
+      "indexes": {
+        "idx_file_owner": {
+          "name": "idx_file_owner",
+          "columns": [
+            {
+              "expression": "ownerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_file_folder": {
+          "name": "idx_file_folder",
+          "columns": [
+            {
+              "expression": "folderId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "files_folderId_folders_id_fk": {
+          "name": "files_folderId_folders_id_fk",
+          "tableFrom": "files",
+          "tableTo": "folders",
+          "columnsFrom": [
+            "folderId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "files_ownerId_users_id_fk": {
+          "name": "files_ownerId_users_id_fk",
+          "tableFrom": "files",
+          "tableTo": "users",
+          "columnsFrom": [
+            "ownerId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.folders": {
+      "name": "folders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4\n      ()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parentId": {
+          "name": "parentId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now\n      ()"
+        }
+      },
+      "indexes": {
+        "idx_folder_owner": {
+          "name": "idx_folder_owner",
+          "columns": [
+            {
+              "expression": "ownerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "folders_ownerId_users_id_fk": {
+          "name": "folders_ownerId_users_id_fk",
+          "tableFrom": "folders",
+          "tableTo": "users",
+          "columnsFrom": [
+            "ownerId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "folders_parentId_folders_id_fk": {
+          "name": "folders_parentId_folders_id_fk",
+          "tableFrom": "folders",
+          "tableTo": "folders",
+          "columnsFrom": [
+            "parentId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shares": {
+      "name": "shares",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4\n      ()"
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fileId": {
+          "name": "fileId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "folderId": {
+          "name": "folderId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "downloadCount": {
+          "name": "downloadCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now\n      ()"
+        }
+      },
+      "indexes": {
+        "idx_share_file": {
+          "name": "idx_share_file",
+          "columns": [
+            {
+              "expression": "fileId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_share_folder": {
+          "name": "idx_share_folder",
+          "columns": [
+            {
+              "expression": "folderId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_share_created_by": {
+          "name": "idx_share_created_by",
+          "columns": [
+            {
+              "expression": "createdBy",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "shares_fileId_files_id_fk": {
+          "name": "shares_fileId_files_id_fk",
+          "tableFrom": "shares",
+          "tableTo": "files",
+          "columnsFrom": [
+            "fileId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "shares_folderId_folders_id_fk": {
+          "name": "shares_folderId_folders_id_fk",
+          "tableFrom": "shares",
+          "tableTo": "folders",
+          "columnsFrom": [
+            "folderId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "shares_createdBy_users_id_fk": {
+          "name": "shares_createdBy_users_id_fk",
+          "tableFrom": "shares",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "shares_token_unique": {
+          "name": "shares_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4\n    ()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "NULL"
+        },
+        "profilePicture": {
+          "name": "profilePicture",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "NULL"
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "NULL"
+        },
+        "loginAt": {
+          "name": "loginAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "NULL"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now\n    ()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now\n    ()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_id_unique": {
+          "name": "users_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1747150686449,
       "tag": "0001_right_whirlwind",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1747303085353,
+      "tag": "0002_yellow_mojo",
+      "breakpoints": true
     }
   ]
 }

--- a/src/config/db/schema.ts
+++ b/src/config/db/schema.ts
@@ -1,7 +1,9 @@
-import { pgTable, timestamp, varchar } from 'drizzle-orm/pg-core';
+import { index, pgTable, timestamp, varchar } from 'drizzle-orm/pg-core';
 import { uuid } from 'drizzle-orm/pg-core/columns/uuid';
 import { sql } from 'drizzle-orm';
 import { date } from 'drizzle-orm/pg-core/columns/date';
+import { integer } from 'drizzle-orm/pg-core/columns/integer';
+import { text } from 'drizzle-orm/pg-core/columns/text';
 
 export const usersTable = pgTable('users', {
   id: uuid().unique().primaryKey().default(sql`uuid_generate_v4
@@ -18,5 +20,72 @@ export const usersTable = pgTable('users', {
     ()`),
 });
 
+export const foldersTable = pgTable(
+  'folders',
+  {
+    id: uuid().primaryKey().default(sql`uuid_generate_v4
+      ()`),
+    name: varchar({ length: 255 }).notNull(),
+    ownerId: uuid()
+      .references(() => usersTable.id)
+      .notNull(),
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return,@typescript-eslint/no-unsafe-member-access
+    parentId: uuid().references(() => foldersTable.id),
+    deletedAt: timestamp(),
+    createdAt: timestamp().default(sql`now
+      ()`),
+  },
+  (table) => [index('idx_folder_owner').on(table.ownerId)],
+);
+
+export const filesTable = pgTable(
+  'files',
+  {
+    id: uuid().primaryKey().default(sql`uuid_generate_v4
+      ()`),
+    name: varchar({ length: 255 }).notNull(),
+    mimeType: varchar({ length: 100 }).notNull(),
+    size: integer().notNull(),
+    path: text().notNull(),
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return,@typescript-eslint/no-unsafe-member-access
+    folderId: uuid().references(() => foldersTable.id),
+    ownerId: uuid()
+      .references(() => usersTable.id)
+      .notNull(),
+    deletedAt: timestamp(),
+    createdAt: timestamp().default(sql`now
+      ()`),
+  },
+  (table) => [
+    index('idx_file_owner').on(table.ownerId),
+    index('idx_file_folder').on(table.folderId),
+  ],
+);
+
+export const sharesTable = pgTable(
+  'shares',
+  {
+    id: uuid().primaryKey().default(sql`uuid_generate_v4
+      ()`),
+    token: varchar({ length: 64 }).unique().notNull(),
+    fileId: uuid().references(() => filesTable.id),
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return,@typescript-eslint/no-unsafe-member-access
+    folderId: uuid().references(() => foldersTable.id),
+    createdBy: uuid()
+      .references(() => usersTable.id)
+      .notNull(),
+    password: varchar({ length: 100 }),
+    expiresAt: timestamp(),
+    downloadCount: integer().default(0),
+    createdAt: timestamp().default(sql`now
+      ()`),
+  },
+  (table) => [
+    index('idx_share_file').on(table.fileId),
+    index('idx_share_folder').on(table.folderId),
+    index('idx_share_created_by').on(table.createdBy),
+  ],
+);
+
 export type User = typeof usersTable.$inferSelect;
-export type NewUser = typeof usersTable.$inferInsert;
+export type Folder = typeof foldersTable.$inferSelect;


### PR DESCRIPTION
This pull request introduces schema changes to support a file and folder sharing system. It includes the creation of new database tables, updates to the schema definition in TypeScript, and adjustments to the database migration metadata. Below are the key changes:

### Database Schema Changes
* Added three new tables: `files`, `folders`, and `shares`, with appropriate columns, constraints, and foreign key relationships. These tables support file storage, folder organization, and sharing functionality. (`drizzle/0002_yellow_mojo.sql`, [drizzle/0002_yellow_mojo.sqlR1-R54](diffhunk://#diff-d5a69c0df4f268564f445dac40eb6cb2eac6527a16ac719d38ae28fdbfc38eabR1-R54))
* Added indexes to optimize queries on key columns such as `ownerId`, `folderId`, and `createdBy` in the `files`, `folders`, and `shares` tables. (`drizzle/0002_yellow_mojo.sql`, [drizzle/0002_yellow_mojo.sqlR1-R54](diffhunk://#diff-d5a69c0df4f268564f445dac40eb6cb2eac6527a16ac719d38ae28fdbfc38eabR1-R54))
* Removed the `deletedAt` column from the `users` table. (`drizzle/0002_yellow_mojo.sql`, [drizzle/0002_yellow_mojo.sqlR1-R54](diffhunk://#diff-d5a69c0df4f268564f445dac40eb6cb2eac6527a16ac719d38ae28fdbfc38eabR1-R54))

### Migration Metadata Updates
* Updated `_journal.json` to include metadata for the new migration file `0002_yellow_mojo`. (`drizzle/meta/_journal.json`, [drizzle/meta/_journal.jsonR18-R24](diffhunk://#diff-349e2e5efe6c282645244197ec3a36bee4f6fbc9988ee5acc46a05603f6829cdR18-R24))

### TypeScript Schema Updates
* Defined new schema objects in `schema.ts` for the `files`, `folders`, and `shares` tables, including their columns, foreign key relationships, and indexes. (`src/config/db/schema.ts`, [src/config/db/schema.tsR23-R91](diffhunk://#diff-e2f821b6fd74ded9804f6454b34f8de1042d287bba3521163b7dfafc18c172a7R23-R91))
* Updated imports in `schema.ts` to include new column types (`integer` and `text`) and the `index` utility. (`src/config/db/schema.ts`, [src/config/db/schema.tsL1-R6](diffhunk://#diff-e2f821b6fd74ded9804f6454b34f8de1042d287bba3521163b7dfafc18c172a7L1-R6))